### PR TITLE
chore: exclude .lintr from package build

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -9,3 +9,4 @@
 pkgdown
 docs
 ^README\.qmd$
+^\.lintr$


### PR DESCRIPTION
## Summary
The `.lintr` config file was bundled into the built package tarball, triggering the r-universe **`checking for hidden files and directories`** NOTE. This adds `^\.lintr$` to `.Rbuildignore` so it is excluded from the build while remaining in the repo for the code-quality workflow.

## Test plan
- `R CMD build` → `tar tzf` confirms `.lintr` is no longer in the tarball.
- NOTE clears on next r-universe rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)